### PR TITLE
打刻すると打刻したタスクがタスク一覧の先頭にきてしまうので、変わらないように修正

### DIFF
--- a/lib/infrastructure/db/dao.dart
+++ b/lib/infrastructure/db/dao.dart
@@ -73,7 +73,7 @@ class DAO implements Repository {
       dones.id as done_id, dones.done_at as dones_done_at, dones.created_at as dones_created_at, dones.updated_at as dones_updated_at
     FROM tasks
     LEFT JOIN dones ON tasks.id = dones.task_id
-    ORDER BY tasks.order_num ASC, dones.created_at DESC
+    ORDER BY tasks.order_num ASC, tasks.created_at DESC, dones.created_at DESC
     ''');
 
     Map<int, Map<String, dynamic>> tasksMap = {};


### PR DESCRIPTION
## Jiraの課題へのリンク

## 目的（実現したいこと）
表題の通り。

## やったこと
SQLでタスクリストを取得するときに以下の条件で取得するように対応
1. tasks.order_num ASC
2. tasks.created_at DESC
3. dones.created_at DESC


## 動作確認

## 補足
